### PR TITLE
🔒 Security Fixes (HIGH Priority)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,19 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+	        <!-- SECURITY FIX: Updated the version of the `tomcat-embed-core` package to 10.1.44 to resolve the noted vulnerability. This version includes a fix for the DoS issue in multipart upload, which ensures resources are allocated with limits and throttling, maintaining better security. -->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>10.1.44</version>
+        </dependency>
+        <!-- SECURITY FIX: The updated version number of spring-boot dependency ensures that the spring-boot library is updated with the latest fixes and addresses the identified vulnerability. It is essential to use the latest, unaffected version of the library to ensure that your application is secure. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+            <version>3.4.8</version>
+        </dependency>
+</dependencies>
 
 	<build>
 		<plugins>

--- a/target/classes/META-INF/maven/com.archer.monolithic/Trivia/pom.xml
+++ b/target/classes/META-INF/maven/com.archer.monolithic/Trivia/pom.xml
@@ -54,7 +54,19 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+	        <!-- SECURITY FIX: The provided code snippet is a fixed version of the Tomcat dependency. The vulnerability in Apache Tomcat mentioned relates to a lack of limitation or throttling of resources, which can lead to a DoS attack. The fixed version of the dependency, 10.1.44, is not susceptible to this issue. -->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>10.1.44</version>
+        </dependency>
+        <!-- SECURITY FIX: The updated version of spring-boot dependency addresses a vulnerability where EndpointRequest.to() creates a matcher for null/** if the actuator endpoint is not exposed. This resolution incorporates the corrected code, updating the spring-boot version to the latest version to ensure optimal security. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+            <version>3.4.8</version>
+        </dependency>
+</dependencies>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
## 🔒 Security Fixes (HIGH Priority)

⚠️ **MANUAL APPROVAL REQUIRED** - High/Critical security issues detected

### Summary
- **Fixes Applied**: 4
- **Approval Level**: HIGH
- **Generated by**: SecureGen AI Agent

### Vulnerabilities Found
- **tomcat: Apache Tomcat DoS in multipart upload** (High)
- **tomcat: http/2 "MadeYouReset" DoS attack through HTTP/2 control frames** (High)
- **tomcat: Apache Tomcat: DoS via malformed HTTP/2 PRIORITY_UPDATE frame** (Medium)
- **tomcat: Apache Tomcat: Security constraint bypass for pre/post-resources** (Medium)
- **tomcat: Apache Tomcat: Bypass of rules in Rewrite Valve** (Low)
- ... and 17 more

### Applied Fixes
- ✅ **trivy_CVE-2025-48988**: Updated the version of the `tomcat-embed-core` package to 10.1.44 to resolve the noted vulnerability. This version includes a fix for the DoS issue in multipart upload, which ensures resources are allocated with limits and throttling, maintaining better security.
- ❌ **trivy_CVE-2025-48989**: Failed to apply - Failed to apply code changes
- ❌ **trivy_CVE-2025-49146**: Failed to apply - Failed to apply code changes
- ✅ **trivy_CVE-2025-22235**: The updated version number of spring-boot dependency ensures that the spring-boot library is updated with the latest fixes and addresses the identified vulnerability. It is essential to use the latest, unaffected version of the library to ensure that your application is secure.
- ✅ **trivy_CVE-2025-48988**: The provided code snippet is a fixed version of the Tomcat dependency. The vulnerability in Apache Tomcat mentioned relates to a lack of limitation or throttling of resources, which can lead to a DoS attack. The fixed version of the dependency, 10.1.44, is not susceptible to this issue.
- ❌ **trivy_CVE-2025-48989**: Failed to apply - Failed to apply code changes
- ❌ **trivy_CVE-2025-49146**: Failed to apply - Failed to apply code changes
- ✅ **trivy_CVE-2025-22235**: The updated version of spring-boot dependency addresses a vulnerability where EndpointRequest.to() creates a matcher for null/** if the actuator endpoint is not exposed. This resolution incorporates the corrected code, updating the spring-boot version to the latest version to ensure optimal security.

### Next Steps
1. 👀 **Review the changes carefully**
2. ✅ **Approve and merge** if fixes look good
3. 🔄 **Rollback** if changes are not suitable

---
*Generated by SecureGen AI Agent at 2025-09-08 12:40:56*