### PR TITLE
🔒 Security Fixes (HIGH Priority)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,19 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+	        <!-- SECURITY FIX: Updated the version of tomcat-embed-core to 10.1.44 to resolve the vulnerability affecting previous versions of tomcat. 10.1.44 is not affected by the mentioned DoS vulnerability in multipart upload. This fix follows the recommendation provided by the CVE. -->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>10.1.44</version>
+        </dependency>
+        <!-- SECURITY FIX: The original code used a vulnerable version of the spring-boot dependency. The fixed code uses the latest version of spring-boot, which addresses the vulnerability because the newest versions of Spring Boot contain fixes for security vulnerabilities found in older versions. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+            <version>3.4.8</version>
+        </dependency>
+</dependencies>
 
 	<build>
 		<plugins>

--- a/target/classes/META-INF/maven/com.archer.monolithic/Trivia/pom.xml
+++ b/target/classes/META-INF/maven/com.archer.monolithic/Trivia/pom.xml
@@ -54,7 +54,19 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+	        <!-- SECURITY FIX: The fixed code updates the version of the `tomcat-embed-core` package to version 10.1.44, which addresses the noted vulnerability. This fix ensures that the code is no longer affected by the vulnerability, and at the same time still utilizes the same versioning scheme for downstream dependencies. -->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>10.1.44</version>
+        </dependency>
+        <!-- SECURITY FIX: The updated version of spring-boot dependency addresses a vulnerability where EndpointRequest.to() creates a matcher for null/** if the actuator endpoint is not exposed. This resolution ensures you have the latest fixes from the spring-boot developers, resolving this and other potential issues. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+            <version>3.4.8</version>
+        </dependency>
+</dependencies>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
## 🔒 Security Fixes (HIGH Priority)

⚠️ **MANUAL APPROVAL REQUIRED** - High/Critical security issues detected

### Summary
- **Fixes Applied**: 4
- **Approval Level**: HIGH
- **Generated by**: SecureGen AI Agent

### Vulnerabilities Found
- **tomcat: Apache Tomcat DoS in multipart upload** (High)
- **tomcat: http/2 "MadeYouReset" DoS attack through HTTP/2 control frames** (High)
- **tomcat: Apache Tomcat: DoS via malformed HTTP/2 PRIORITY_UPDATE frame** (Medium)
- **tomcat: Apache Tomcat: Security constraint bypass for pre/post-resources** (Medium)
- **pgjdbc: pgjdbc insecure authentication in channel binding** (High)
- ... and 11 more

### Applied Fixes
- ✅ **trivy_CVE-2025-48988**: Updated the version of tomcat-embed-core to 10.1.44 to resolve the vulnerability affecting previous versions of tomcat. 10.1.44 is not affected by the mentioned DoS vulnerability in multipart upload. This fix follows the recommendation provided by the CVE.
- ❌ **trivy_CVE-2025-48989**: Failed to apply - Failed to apply code changes
- ❌ **trivy_CVE-2025-49146**: Failed to apply - Failed to apply code changes
- ✅ **trivy_CVE-2025-22235**: The original code used a vulnerable version of the spring-boot dependency. The fixed code uses the latest version of spring-boot, which addresses the vulnerability because the newest versions of Spring Boot contain fixes for security vulnerabilities found in older versions.
- ✅ **trivy_CVE-2025-48988**: The fixed code updates the version of the `tomcat-embed-core` package to version 10.1.44, which addresses the noted vulnerability. This fix ensures that the code is no longer affected by the vulnerability, and at the same time still utilizes the same versioning scheme for downstream dependencies.
- ❌ **trivy_CVE-2025-48989**: Failed to apply - Failed to apply code changes
- ❌ **trivy_CVE-2025-49146**: Failed to apply - Failed to apply code changes
- ✅ **trivy_CVE-2025-22235**: The updated version of spring-boot dependency addresses a vulnerability where EndpointRequest.to() creates a matcher for null/** if the actuator endpoint is not exposed. This resolution ensures you have the latest fixes from the spring-boot developers, resolving this and other potential issues.

### Next Steps
1. 👀 **Review the changes carefully**
2. ✅ **Approve and merge** if fixes look good
3. 🔄 **Rollback** if changes are not suitable

---
*Generated by SecureGen AI Agent at 2025-09-09 12:31:27*