### PR TITLE
🔒 Security Fixes (LOW Priority) - CVE-2025-31650

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,13 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+	        <!-- SECURITY FIX: The vulnerability is addressed by upgrading Apache Tomcat embed core to version 10.1.44 or higher. This version contains a fix for the improper input validation in HTTP/2 PRIORITY_UPDATE frames that caused the memory leak. -->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>10.1.44</version>
+        </dependency>
+</dependencies>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
## 🔒 Security Fixes (LOW Priority) - CVE-2025-31650

### Summary
- **Fixes Applied**: 1
- **Approval Level**: LOW
- **Generated by**: SecureGen AI Agent

### Applied Fixes
- ✅ **trivy_CVE-2025-31650**: The vulnerability is addressed by upgrading Apache Tomcat embed core to version 10.1.44 or higher. This version contains a fix for the improper input validation in HTTP/2 PRIORITY_UPDATE frames that caused the memory leak.

### Next Steps
1. 🤖 **Auto-approved** - Low risk changes
2. ✅ **Ready to merge** or review as needed

---
*Generated by SecureGen AI Agent at 2025-09-11 11:20:29*