### PR TITLE
🔒 Security Fixes (LOW Priority) - CVE-2025-48989

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,13 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+	        <!-- SECURITY FIX: The vulnerability in Apache Tomcat 10.1.36 was addressed in version 10.1.44.  Updating to this version mitigates the "MadeYouReset" denial-of-service attack via HTTP/2 control frames. -->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>10.1.44</version>
+        </dependency>
+</dependencies>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
## 🔒 Security Fixes (LOW Priority) - CVE-2025-48989

### Summary
- **Fixes Applied**: 1
- **Approval Level**: LOW
- **Generated by**: SecureGen AI Agent

### Applied Fixes
- ✅ **trivy_CVE-2025-48989**: The vulnerability in Apache Tomcat 10.1.36 was addressed in version 10.1.44.  Updating to this version mitigates the "MadeYouReset" denial-of-service attack via HTTP/2 control frames.

### Next Steps
1. 🤖 **Auto-approved** - Low risk changes
2. ✅ **Ready to merge** or review as needed

---
*Generated by SecureGen AI Agent at 2025-09-12 12:34:14*