### PR TITLE
🔒 Security Fixes (MEDIUM Priority) - CVE-2025-31650

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,13 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+	        <!-- SECURITY FIX: The vulnerability in Apache Tomcat 10.1.36 allows denial of service via malformed HTTP/2 PRIORITY_UPDATE frames. Updating to version 10.1.44 or later addresses this by improving error handling and preventing memory leaks. -->
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>10.1.44</version>
+        </dependency>
+</dependencies>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
## 🔒 Security Fixes (MEDIUM Priority) - CVE-2025-31650

### Summary
- **Fixes Applied**: 1
- **Approval Level**: MEDIUM
- **Generated by**: SecureGen AI Agent

### Vulnerabilities Found
- **tomcat: Apache Tomcat: DoS via malformed HTTP/2 PRIORITY_UPDATE frame** (Medium)

### Applied Fixes
- ✅ **trivy_CVE-2025-31650**: The vulnerability in Apache Tomcat 10.1.36 allows denial of service via malformed HTTP/2 PRIORITY_UPDATE frames. Updating to version 10.1.44 or later addresses this by improving error handling and preventing memory leaks.

### Next Steps
1. 🤖 **Auto-approved** - Low risk changes
2. ✅ **Ready to merge** or review as needed

---
*Generated by SecureGen AI Agent at 2025-09-18 10:59:24*